### PR TITLE
Fix Prowler workflow environment name

### DIFF
--- a/.github/workflows/publish-prowler.yml
+++ b/.github/workflows/publish-prowler.yml
@@ -12,7 +12,7 @@ jobs:
   build-and-push:
     name: Build and push Prowler image
     runs-on: ubuntu-latest
-    environment: dockerhub
+    environment: Docker Hub
     steps:
       - uses: actions/checkout@v4
 


### PR DESCRIPTION
## Summary
- Fix GitHub environment name from `dockerhub` to `Docker Hub` to match the actual environment where secrets are configured

## Test plan
- [ ] Merge, re-tag, and verify the workflow succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)