### PR TITLE
Update Prowler image to carlosinfantes/cloudsecure-prowler

### DIFF
--- a/.github/workflows/publish-prowler.yml
+++ b/.github/workflows/publish-prowler.yml
@@ -36,5 +36,5 @@ jobs:
           platforms: linux/amd64
           push: true
           tags: |
-            cloudsecure/prowler:latest
-            cloudsecure/prowler:${{ steps.version.outputs.version }}
+            carlosinfantes/cloudsecure-prowler:latest
+            carlosinfantes/cloudsecure-prowler:${{ steps.version.outputs.version }}

--- a/Makefile
+++ b/Makefile
@@ -17,7 +17,7 @@ endif
 AWS_PROFILE    ?= default
 AWS_REGION     ?= eu-west-1
 CLOUDSECURE_ENV ?= dev
-PROWLER_IMAGE  ?= cloudsecure/prowler:latest
+PROWLER_IMAGE  ?= carlosinfantes/cloudsecure-prowler:latest
 SKIP_PROWLER   ?= false
 
 INFRA_DIR      := infrastructure

--- a/deploy.sh
+++ b/deploy.sh
@@ -121,7 +121,7 @@ CLOUDSECURE_ENV=${CLOUDSECURE_ENV:-dev}
 
 # Prowler
 SKIP_PROWLER=false
-PROWLER_IMAGE="cloudsecure/prowler:latest"
+PROWLER_IMAGE="carlosinfantes/cloudsecure-prowler:latest"
 if [ "$HAS_DOCKER" = false ]; then
   SKIP_PROWLER=true
 else


### PR DESCRIPTION
## Summary
- Update Docker Hub image name to `carlosinfantes/cloudsecure-prowler` in workflow, Makefile, and deploy.sh

🤖 Generated with [Claude Code](https://claude.com/claude-code)