### PR TITLE
Fix Podman compatibility for Prowler image pull

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -17,7 +17,7 @@ endif
 AWS_PROFILE    ?= default
 AWS_REGION     ?= eu-west-1
 CLOUDSECURE_ENV ?= dev
-PROWLER_IMAGE  ?= carlosinfantes/cloudsecure-prowler:latest
+PROWLER_IMAGE  ?= docker.io/carlosinfantes/cloudsecure-prowler:latest
 SKIP_PROWLER   ?= false
 
 # Container runtime auto-detection (Docker preferred, Podman fallback)

--- a/deploy.sh
+++ b/deploy.sh
@@ -124,7 +124,7 @@ CLOUDSECURE_ENV=${CLOUDSECURE_ENV:-dev}
 
 # Prowler
 SKIP_PROWLER=false
-PROWLER_IMAGE="carlosinfantes/cloudsecure-prowler:latest"
+PROWLER_IMAGE="docker.io/carlosinfantes/cloudsecure-prowler:latest"
 if [ -z "$CONTAINER_CMD" ]; then
   SKIP_PROWLER=true
 else

--- a/lambdas/tests/conftest.py
+++ b/lambdas/tests/conftest.py
@@ -2,7 +2,7 @@
 
 import os
 import sys
-from datetime import UTC, datetime
+from datetime import datetime
 from unittest.mock import MagicMock
 from uuid import uuid4
 

--- a/lambdas/tests/test_base_analyzer.py
+++ b/lambdas/tests/test_base_analyzer.py
@@ -4,7 +4,6 @@ import logging
 from unittest.mock import MagicMock, patch
 from uuid import uuid4
 
-import pytest
 from botocore.exceptions import ClientError
 
 from analyzers.base import BaseAnalyzer, run_analyzer

--- a/lambdas/tests/test_cloudtrail_analyzer.py
+++ b/lambdas/tests/test_cloudtrail_analyzer.py
@@ -210,12 +210,14 @@ class TestCloudTrailAnalyzerRootUsage:
             "Events": [
                 {
                     "EventName": "OrgAction",
-                    "CloudTrailEvent": json.dumps({
-                        "userIdentity": {
-                            "type": "Root",
-                            "sessionContext": {"assumedRoot": "true"},
+                    "CloudTrailEvent": json.dumps(
+                        {
+                            "userIdentity": {
+                                "type": "Root",
+                                "sessionContext": {"assumedRoot": "true"},
+                            }
                         }
-                    }),
+                    ),
                 },
             ]
         }

--- a/lambdas/tests/test_cloudtrail_analyzer.py
+++ b/lambdas/tests/test_cloudtrail_analyzer.py
@@ -1,11 +1,8 @@
 """Tests for CloudTrail Analyzer."""
 
 import json
-from datetime import UTC, datetime, timedelta
 from unittest.mock import MagicMock, patch
 from uuid import uuid4
-
-from botocore.exceptions import ClientError
 
 from analyzers.cloudtrail_analyzer import CloudTrailAnalyzer, handler
 from shared.models import FindingSeverity
@@ -308,5 +305,5 @@ class TestCloudTrailAnalyzerHandler:
     @patch("analyzers.cloudtrail_analyzer.run_analyzer")
     def test_handler_delegates(self, mock_run):
         mock_run.return_value = {"success": True}
-        result = handler({"assessmentId": "test"}, None)
+        handler({"assessmentId": "test"}, None)
         mock_run.assert_called_once_with(CloudTrailAnalyzer, {"assessmentId": "test"})

--- a/lambdas/tests/test_encryption_analyzer.py
+++ b/lambdas/tests/test_encryption_analyzer.py
@@ -252,5 +252,5 @@ class TestEncryptionAnalyzerHandler:
     @patch("analyzers.encryption_analyzer.run_analyzer")
     def test_handler_delegates(self, mock_run):
         mock_run.return_value = {"success": True}
-        result = handler({"assessmentId": "test"}, None)
+        handler({"assessmentId": "test"}, None)
         mock_run.assert_called_once_with(EncryptionAnalyzer, {"assessmentId": "test"})

--- a/lambdas/tests/test_iam_analyzer.py
+++ b/lambdas/tests/test_iam_analyzer.py
@@ -4,8 +4,6 @@ from datetime import UTC, datetime, timedelta
 from unittest.mock import MagicMock, patch
 from uuid import uuid4
 
-import pytest
-
 from analyzers.iam_analyzer import IAMAnalyzer, handler
 from shared.models import FindingSeverity
 

--- a/lambdas/tests/test_iam_analyzer.py
+++ b/lambdas/tests/test_iam_analyzer.py
@@ -118,7 +118,11 @@ class TestIAMAnalyzerAccessKeys:
         recent_date = datetime.now(UTC) - timedelta(days=10)
         mock_iam.list_access_keys.return_value = {
             "AccessKeyMetadata": [
-                {"AccessKeyId": "AKIAIOSFODNN7EXAMPLE", "CreateDate": recent_date, "Status": "Active"}
+                {
+                    "AccessKeyId": "AKIAIOSFODNN7EXAMPLE",
+                    "CreateDate": recent_date,
+                    "Status": "Active",
+                }
             ]
         }
 
@@ -134,12 +138,19 @@ class TestIAMAnalyzerOverprivileged:
 
         mock_paginator = MagicMock()
         mock_paginator.paginate.return_value = [
-            {"Users": [{"UserName": "admin-user", "Arn": "arn:aws:iam::123456789012:user/admin-user"}]}
+            {
+                "Users": [
+                    {"UserName": "admin-user", "Arn": "arn:aws:iam::123456789012:user/admin-user"}
+                ]
+            }
         ]
         mock_iam.get_paginator.return_value = mock_paginator
         mock_iam.list_attached_user_policies.return_value = {
             "AttachedPolicies": [
-                {"PolicyName": "AdministratorAccess", "PolicyArn": "arn:aws:iam::aws:policy/AdministratorAccess"}
+                {
+                    "PolicyName": "AdministratorAccess",
+                    "PolicyArn": "arn:aws:iam::aws:policy/AdministratorAccess",
+                }
             ]
         }
 
@@ -162,7 +173,9 @@ class TestIAMAnalyzerOverprivileged:
                         "Arn": "arn:aws:iam::123456789012:role/open-role",
                         "Path": "/",
                         "AssumeRolePolicyDocument": {
-                            "Statement": [{"Effect": "Allow", "Principal": "*", "Action": "sts:AssumeRole"}]
+                            "Statement": [
+                                {"Effect": "Allow", "Principal": "*", "Action": "sts:AssumeRole"}
+                            ]
                         },
                     }
                 ]
@@ -189,7 +202,9 @@ class TestIAMAnalyzerOverprivileged:
                         "Arn": "arn:aws:iam::123456789012:role/aws-service-role/autoscaling",
                         "Path": "/aws-service-role/autoscaling.amazonaws.com/",
                         "AssumeRolePolicyDocument": {
-                            "Statement": [{"Effect": "Allow", "Principal": "*", "Action": "sts:AssumeRole"}]
+                            "Statement": [
+                                {"Effect": "Allow", "Principal": "*", "Action": "sts:AssumeRole"}
+                            ]
                         },
                     }
                 ]

--- a/lambdas/tests/test_network_analyzer.py
+++ b/lambdas/tests/test_network_analyzer.py
@@ -308,5 +308,5 @@ class TestNetworkAnalyzerHandler:
     @patch("analyzers.network_analyzer.run_analyzer")
     def test_handler_delegates(self, mock_run):
         mock_run.return_value = {"success": True}
-        result = handler({"assessmentId": "test"}, None)
+        handler({"assessmentId": "test"}, None)
         mock_run.assert_called_once_with(NetworkAnalyzer, {"assessmentId": "test"})

--- a/lambdas/tests/test_network_analyzer.py
+++ b/lambdas/tests/test_network_analyzer.py
@@ -224,7 +224,9 @@ class TestNetworkAnalyzerVPC:
     def test_default_vpc_with_instances(self):
         analyzer = _make_analyzer()
         mock_ec2 = MagicMock()
-        mock_ec2.describe_vpcs.return_value = {"Vpcs": [{"VpcId": "vpc-default", "IsDefault": True}]}
+        mock_ec2.describe_vpcs.return_value = {
+            "Vpcs": [{"VpcId": "vpc-default", "IsDefault": True}]
+        }
         mock_ec2.describe_instances.return_value = {
             "Reservations": [{"Instances": [{"InstanceId": "i-123"}]}]
         }
@@ -237,7 +239,9 @@ class TestNetworkAnalyzerVPC:
     def test_default_vpc_no_instances(self):
         analyzer = _make_analyzer()
         mock_ec2 = MagicMock()
-        mock_ec2.describe_vpcs.return_value = {"Vpcs": [{"VpcId": "vpc-default", "IsDefault": True}]}
+        mock_ec2.describe_vpcs.return_value = {
+            "Vpcs": [{"VpcId": "vpc-default", "IsDefault": True}]
+        }
         mock_ec2.describe_instances.return_value = {"Reservations": []}
 
         analyzer._check_default_vpc(mock_ec2, "us-east-1")

--- a/lambdas/tests/test_s3_analyzer.py
+++ b/lambdas/tests/test_s3_analyzer.py
@@ -191,5 +191,5 @@ class TestS3AnalyzerHandler:
     @patch("analyzers.s3_analyzer.run_analyzer")
     def test_handler_delegates(self, mock_run):
         mock_run.return_value = {"success": True}
-        result = handler({"assessmentId": "test"}, None)
+        handler({"assessmentId": "test"}, None)
         mock_run.assert_called_once_with(S3Analyzer, {"assessmentId": "test"})

--- a/lambdas/tests/test_s3_analyzer.py
+++ b/lambdas/tests/test_s3_analyzer.py
@@ -87,7 +87,12 @@ class TestS3AnalyzerBucketChecks:
         analyzer = _make_analyzer()
         mock_s3 = MagicMock()
         mock_s3.get_bucket_encryption.side_effect = ClientError(
-            {"Error": {"Code": "ServerSideEncryptionConfigurationNotFoundError", "Message": "none"}},
+            {
+                "Error": {
+                    "Code": "ServerSideEncryptionConfigurationNotFoundError",
+                    "Message": "none",
+                }
+            },
             "GetBucketEncryption",
         )
 
@@ -142,11 +147,18 @@ class TestS3AnalyzerBucketChecks:
         analyzer = _make_analyzer()
         mock_s3 = MagicMock()
         mock_s3.get_bucket_policy.return_value = {
-            "Policy": json.dumps({
-                "Statement": [
-                    {"Effect": "Allow", "Principal": "*", "Action": "s3:GetObject", "Resource": "*"}
-                ]
-            })
+            "Policy": json.dumps(
+                {
+                    "Statement": [
+                        {
+                            "Effect": "Allow",
+                            "Principal": "*",
+                            "Action": "s3:GetObject",
+                            "Resource": "*",
+                        }
+                    ]
+                }
+            )
         }
 
         analyzer._check_bucket_policy(mock_s3, "test-bucket", "us-east-1")
@@ -158,16 +170,18 @@ class TestS3AnalyzerBucketChecks:
         analyzer = _make_analyzer()
         mock_s3 = MagicMock()
         mock_s3.get_bucket_policy.return_value = {
-            "Policy": json.dumps({
-                "Statement": [
-                    {
-                        "Effect": "Allow",
-                        "Principal": {"AWS": "arn:aws:iam::111111111111:root"},
-                        "Action": "s3:GetObject",
-                        "Resource": "*",
-                    }
-                ]
-            })
+            "Policy": json.dumps(
+                {
+                    "Statement": [
+                        {
+                            "Effect": "Allow",
+                            "Principal": {"AWS": "arn:aws:iam::111111111111:root"},
+                            "Action": "s3:GetObject",
+                            "Resource": "*",
+                        }
+                    ]
+                }
+            )
         }
 
         analyzer._check_bucket_policy(mock_s3, "test-bucket", "us-east-1")


### PR DESCRIPTION
Add docker.io/ registry prefix to PROWLER_IMAGE so Podman can resolve the image name without unqualified-search registries configured.

## Checklist
- [ ] Pre-commit hooks pass (`pre-commit run --all-files`)
- [ ] No real AWS account IDs or credentials
- [ ] Tests pass (`pytest` / `npm test`)
- [ ] CDK synthesizes (`cd infrastructure && npm run build && npx cdk synth`)
